### PR TITLE
Bug-fix: NaN carry weight with "Coin Weight" enabled

### DIFF
--- a/inventory-plus.js
+++ b/inventory-plus.js
@@ -80,10 +80,8 @@ class InventoryPlus {
             let itemType = this.inventoryPlus.getItemType(data.data);
             if (itemType !== targetType) {
                 let categoryWeight = this.inventoryPlus.getCategoryItemWeight(targetType);
-                console.log(dropedItem)
                 let itemWeight = dropedItem.data.data.weight * dropedItem.data.data.quantity;
                 let maxWeight = Number(this.inventoryPlus.customCategorys[targetType].maxWeight ? this.inventoryPlus.customCategorys[targetType].maxWeight : 0);
-                console.log(maxWeight,categoryWeight,itemWeight);
                 if (maxWeight == NaN || maxWeight <= 0 || maxWeight >= (categoryWeight + itemWeight)) {
                     await dropedItem.update({ 'flags.inventory-plus.category': targetType });
                     itemType = targetType;

--- a/inventory-plus.js
+++ b/inventory-plus.js
@@ -465,7 +465,6 @@ class InventoryPlus {
             let section = inventory[id];
             if (section.ignoreWeight !== true) {
                 for (let i of section.items) {
-                    console.log(i);
                     customWeight += i.totalWeight;
                 }
             }

--- a/inventory-plus.js
+++ b/inventory-plus.js
@@ -473,8 +473,12 @@ class InventoryPlus {
 
         let coinWeight = 0
         if (game.settings.get("dnd5e", "currencyWeight")) {
-            let numCoins = Object.values(currency).reduce((val, denom) => val += Math.max(denom, 0), 0);
-            coinWeight = Math.round((numCoins * 10) / CONFIG.DND5E.encumbrance.currencyPerWeight) / 10;
+			let numCoins = Object.values(currency).reduce((val, denom) => val += Math.max(denom, 0), 0);
+			if(game.settings.get("dnd5e", "metricWeightUnits")){
+				coinWeight = Math.round((numCoins * 10) / CONFIG.DND5E.encumbrance.currencyPerWeight.metric) / 10;
+			}else{
+			    coinWeight = Math.round((numCoins * 10) / CONFIG.DND5E.encumbrance.currencyPerWeight.imperial) / 10;
+			}
         }
         customWeight += coinWeight;
 

--- a/inventory-plus.js
+++ b/inventory-plus.js
@@ -80,9 +80,11 @@ class InventoryPlus {
             let itemType = this.inventoryPlus.getItemType(data.data);
             if (itemType !== targetType) {
                 let categoryWeight = this.inventoryPlus.getCategoryItemWeight(targetType);
-                let itemWeight = dropedItem.data.data.weight * dropedItem.data.data.quantity;
+                //console.log(dropedItem);
+				let itemWeight = dropedItem.data.data.weight * dropedItem.data.data.quantity;
                 let maxWeight = Number(this.inventoryPlus.customCategorys[targetType].maxWeight ? this.inventoryPlus.customCategorys[targetType].maxWeight : 0);
-                if (maxWeight == NaN || maxWeight <= 0 || maxWeight >= (categoryWeight + itemWeight)) {
+                //console.log(maxWeight,categoryWeight,itemWeight);
+				if (maxWeight == NaN || maxWeight <= 0 || maxWeight >= (categoryWeight + itemWeight)) {
                     await dropedItem.update({ 'flags.inventory-plus.category': targetType });
                     itemType = targetType;
                 } else {
@@ -463,6 +465,7 @@ class InventoryPlus {
             let section = inventory[id];
             if (section.ignoreWeight !== true) {
                 for (let i of section.items) {
+					//console.log(i);
                     customWeight += i.totalWeight;
                 }
             }

--- a/module.json
+++ b/module.json
@@ -8,9 +8,9 @@
 	"esmodules": ["./inventory-plus.js"],
 	"styles": ["inventory-plus.css"],
 	"packs": [],
-    "url": "https://github.com/syl3r86/inventory-plus",
-    "manifest": "https://raw.githubusercontent.com/syl3r86/inventory-plus/master/module.json",
-    "download": "https://github.com/syl3r86/inventory-plus/archive/master.zip",
+    "url": "https://github.com/ZeroXNoxus/inventory-plus",
+    "manifest": "https://raw.githubusercontent.com/ZeroXNoxus/inventory-plus/master/module.json",
+    "download": "https://github.com/ZeroXNoxus/inventory-plus/archive/refs/heads/master.zip",
     "minimumCoreVersion": "0.8.6",
-    "compatibleCoreVersion": "0.8.6"
+    "compatibleCoreVersion": "0.8.8"
 }

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
 	"name": "inventory-plus",
 	"title": "Inventory+",
 	"description": "Enhances the default dnd5e sheets inventory to allow for reorganization",
-	"version": "0.3.5",
+	"version": "0.3.6",
 	"author": "Felix#6196",
 	"systems": ["dnd5e"],
 	"esmodules": ["./inventory-plus.js"],

--- a/module.json
+++ b/module.json
@@ -1,3 +1,4 @@
+
 {
 	"name": "inventory-plus",
 	"title": "Inventory+",
@@ -8,9 +9,9 @@
 	"esmodules": ["./inventory-plus.js"],
 	"styles": ["inventory-plus.css"],
 	"packs": [],
-    "url": "https://github.com/ZeroXNoxus/inventory-plus",
-    "manifest": "https://raw.githubusercontent.com/ZeroXNoxus/inventory-plus/master/module.json",
-    "download": "https://github.com/ZeroXNoxus/inventory-plus/archive/refs/heads/master.zip",
-    "minimumCoreVersion": "0.8.6",
+    "url": "https://github.com/syl3r86/inventory-plus",
+    "manifest": "https://raw.githubusercontent.com/syl3r86/inventory-plus/master/module.json",
+    "download": "https://github.com/syl3r86/inventory-plus/archive/master.zip",
+    "minimumCoreVersion": "0.8.8",
     "compatibleCoreVersion": "0.8.8"
 }


### PR DESCRIPTION
After updating to DnD5e system 1.4.x, the total weight bar at the bottom of the inventory tab shows as NaN/{Carry Capacity}
(Issue #27).

This calculation error is happening because the system added the ability to switch between metric and imperial unit calculation.

`CONFIG.DND5E.encumbrance.currencyPerWeight`

This line now fetches an object containing the new conversion units. 

The commit fixes this issue by providing a simple decision to determine the game settings measurement units.

Since this issue is related to the newest update, I've taken the liberty to itterate the module version and change the minimum core version to 0.8.8, please review if this is acceptable.

Minor clean up:
- removed console logs spaming the console (added a comment)
- beautified code