### PR TITLE
Bug-fix: NaN carry weight with "Coin Weight" enabled

### DIFF
--- a/inventory-plus.js
+++ b/inventory-plus.js
@@ -477,7 +477,11 @@ class InventoryPlus {
         let coinWeight = 0
         if (game.settings.get("dnd5e", "currencyWeight")) {
             let numCoins = Object.values(currency).reduce((val, denom) => val += Math.max(denom, 0), 0);
-            coinWeight = Math.round((numCoins * 10) / CONFIG.DND5E.encumbrance.currencyPerWeight) / 10;
+            if (game.settings.get("dnd5e", "metricWeightUnits")) {
+                coinWeight = Math.round((numCoins * 10) / CONFIG.DND5E.encumbrance.currencyPerWeight.metric) / 10;
+            } else {
+                coinWeight = Math.round((numCoins * 10) / CONFIG.DND5E.encumbrance.currencyPerWeight.imperial) / 10;
+            }
         }
         customWeight += coinWeight;
 


### PR DESCRIPTION
This is a replacement for #28, removing the cleanup and focusing on the bugfix, but keeping the original commiter.

I created this replacement because I think that the module author is not interested in cleanups, this same author didn't merge previous PR, instead did the changes directly on the codebase after acknowledging and thanking for the previous PRs.  The author is indeed the single commiter of the repo, so any cleanups are just noises. I mean no disrespect to the commiter, I just want to speed up the process.

Copy and paste of the original description:
```
After updating to DnD5e system 1.4.x, the total weight bar at the bottom of the inventory tab shows as NaN/{Carry Capacity}
(Issue #27).

This calculation error is happening because the system added the ability to switch between metric and imperial unit calculation.

CONFIG.DND5E.encumbrance.currencyPerWeight

This line now fetches an object containing the new conversion units.

The commit fixes this issue by providing a simple decision to determine the game settings measurement units.
```